### PR TITLE
Fixes #32 issue

### DIFF
--- a/js/photoswipe.jquery.js
+++ b/js/photoswipe.jquery.js
@@ -15,12 +15,16 @@
       this.photoSwipeOptions = settings.photoswipe ? settings.photoswipe.options : {};
 
       var $galleries = $('.photoswipe-gallery', context);
+      var galleryUID = 0;
       if ($galleries.length) {
-        // loop through all gallery elements and bind events
-        $galleries.each( function (index) {
+        // Loop through all gallery elements, bind events and save Photoswipe slides.
+        $galleries.each( function () {
           var $gallery = $(this);
-          $gallery.attr('data-pswp-uid', index + 1);
+          $gallery.attr('data-pswp-uid', galleryUID);
           $gallery.on('click', Backdrop.behaviors.photoswipe.onThumbnailsClick);
+          // Create and store list of Photoswipe slides.
+          Backdrop.behaviors.photoswipe.pswSlidesFromElements($gallery, galleryUID);
+          galleryUID ++;
         });
       }
       var $imagesWithoutGalleries = $('a.photoswipe', context).filter( function(elem) {
@@ -28,22 +32,53 @@
       });
       if ($imagesWithoutGalleries.length) {
         // We have no galleries just individual images.
-        $imagesWithoutGalleries.each(function (index) {
+        $imagesWithoutGalleries.each(function () {
           $imageLink = $(this);
           $imageLink.wrap('<span class="photoswipe-gallery"></span>');
           var $gallery = $imageLink.parent();
-          $gallery.attr('data-pswp-uid', index + 1);
+          $gallery.attr('data-pswp-uid', galleryUID);
           $gallery.on('click', Backdrop.behaviors.photoswipe.onThumbnailsClick);
-          $galleries.push($gallery);
+          // Create and store list of Photoswipe slides.
+          Backdrop.behaviors.photoswipe.pswSlidesFromElements($gallery, galleryUID);
+          galleryUID ++;
         });
       }
 
       // Parse URL and open gallery if it contains #&pid=3&gid=1
       var hashData = this.parseHash();
-      if (hashData.pid > 0 && hashData.gid > 0) {
-        this.openPhotoSwipe(hashData.pid - 1, $($galleries[hashData.gid - 1]));
+      if (hashData.pid >= 0 && hashData.gid >= 0) {
+        this.openPhotoSwipe(hashData.pid, $($galleries[hashData.gid]));
       }
     },
+
+    /**
+     * Takes data from jQuery collection containing gallery elements and converts it
+     * to Photoswipe slides(items) array. The array is then stored in the galleries list.
+     */
+    pswSlidesFromElements: function(galleryElement, galleryUID) {
+      if (galleryElement.length) {
+        var items = [];
+        var $items = galleryElement.find('a.photoswipe');
+        $items.each(function(index, item) {
+          var $item = $(item);
+          $item.attr('data-pid', index); // Save index as pid in data attribute for easy access to DOM element.
+          var size = $item.data('size') ? $item.data('size').split('x') : ['', ''];
+          items.push(
+            {
+              src: $item.attr('href'),
+              w: size[0],
+              h: size[1],
+              pid: index,  // Save pid for easy slide identification.
+              title: $item.data('overlay-title'),
+              msrc: $item.find('img').attr('src')
+            }
+          );
+        });
+        // Store items array in galleries list for subsequent use.
+        Backdrop.behaviors.photoswipe.galleries[galleryUID] = items;
+      }
+    },
+
     /**
      * Triggers when user clicks on thumbnail.
      *
@@ -58,15 +93,16 @@
       var eTarget = e.target || e.srcElement;
       var $eTarget = $(eTarget);
 
-      // find root element of slide
+      // Find root element of slide.
       var clickedListItem = $eTarget.closest('.photoswipe');
 
       if (!clickedListItem) {
         return true;
       }
 
-      // get the index of the clicked element
-      index = clickedListItem.index('.photoswipe');
+      // Get the index of the clicked element.
+      var index = parseInt(clickedListItem.attr('data-pid'), 10);
+
       if (index >= 0) {
         // Open PhotoSwipe if a valid index was found.
         Backdrop.behaviors.photoswipe.openPhotoSwipe(index, $clickedGallery);
@@ -77,40 +113,31 @@
       }
       return true;
     },
+
     /**
      * Code taken from http://photoswipe.com/documentation/getting-started.html
      * and adjusted accordingly.
      */
     openPhotoSwipe: function (index, galleryElement, options) {
       var pswpElement = $('.pswp')[0];
-      var items = [];
       options = options || Backdrop.behaviors.photoswipe.photoSwipeOptions;
 
-      var images = galleryElement.find('a.photoswipe');
-      images.each(function (index) {
-        var $image = $(this);
-        size = $image.data('size') ? $image.data('size').split('x') : ['', ''];
-        items.push(
-          {
-            src: $image.attr('href'),
-            w: size[0],
-            h: size[1],
-            title: $image.data('overlay-title'),
-            msrc: $image.find('img').attr('src')
-          }
-        );
-      })
+      // Define options.
+      // Define gallery index (for URL).
+      options.index = Number(index);
+      // Define gallery unique id.
+      options.galleryUID = parseInt(galleryElement.data('pswp-uid'), 10);
+      // Use slides pids instead of calculated index.
+      options.galleryPIDs = true;
+      // Get list of Photoswipe slides.
+      var items = Backdrop.behaviors.photoswipe.galleries[options.galleryUID];
 
-      // define options
-      options.index = index;
-      // define gallery index (for URL)
-      options.galleryUID = galleryElement.data('pswp-uid');
-
-      // Add zoom animation function:
+      // Add zoom animation function.
       options.getThumbBoundsFn = function (index) {
-        var tn = galleryElement.find('a.photoswipe:eq(' + index + ') img');
+        var pid = items[index].pid;
+        var tn = galleryElement.find('.photoswipe[data-pid="' + pid + '"] img');
         if (tn.length == 0) {
-          tn = galleryElement.find('a.photoswipe:eq(0) img');
+          tn = galleryElement.find('.photoswipe:eq(0) img');
         }
         if (tn.length == 0) {
           // Return undefined if still null, see https://www.drupal.org/project/photoswipe/issues/3023442
@@ -121,11 +148,11 @@
         return { x: tpos.left, y: tpos.top, w: tw };
       }
 
-      // Pass data to PhotoSwipe and initialize it
+      // Pass data to PhotoSwipe and initialize it.
       var gallery = new PhotoSwipe(pswpElement, PhotoSwipeUI_Default, items, options);
       gallery.init();
-      this.galleries.push(gallery);
     },
+
     /**
      * Parse picture index and gallery index from URL (#&pid=1&gid=2)
      *

--- a/js/photoswipe.jquery.js
+++ b/js/photoswipe.jquery.js
@@ -124,7 +124,7 @@
 
       // Define options.
       // Define gallery index (for URL).
-      options.index = Number(index);
+      options.index = index;
       // Define gallery unique id.
       options.galleryUID = parseInt(galleryElement.data('pswp-uid'), 10);
       // Use slides pids instead of calculated index.
@@ -134,10 +134,9 @@
 
       // Add zoom animation function.
       options.getThumbBoundsFn = function (index) {
-        var pid = items[index].pid;
-        var tn = galleryElement.find('.photoswipe[data-pid="' + pid + '"] img');
+        var tn = galleryElement.find('a.photoswipe[data-pid="' + index + '"] img');
         if (tn.length == 0) {
-          tn = galleryElement.find('.photoswipe:eq(0) img');
+          tn = galleryElement.find('a.photoswipe:eq(0) img');
         }
         if (tn.length == 0) {
           // Return undefined if still null, see https://www.drupal.org/project/photoswipe/issues/3023442


### PR DESCRIPTION
- Fixes gallery uid assignment.
- Image indexes are now stored in data-pid attributes of gallery elements to retrieve them correctly and quickly.
- Slides are calculated at start, when DOM is loaded/changed, and reused each time Photoswipe is launched.